### PR TITLE
Adding headers for cacheable eth methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -88,12 +88,18 @@ const performFetch = async (network, req, res, source) => {
 
 const createInternalError = (msg) => new JsonRpcError.InternalError(new Error(msg))
 
-const getCacheHeader = (method) => {
+const getCacheHeader = (method, req) => {
   switch (method) {
     case 'eth_getBlockByNumber':
-      return 'X-Eth-Get-Block'
+      return [
+        'X-Eth-Get-Block',
+        req.params.toString()
+      ]
     case 'eth_blockNumber':
-      return 'X-Eth-Block'
+      return [
+        'X-Eth-Block',
+        'true'
+      ]
     default:
       return null
   }
@@ -112,19 +118,20 @@ const fetchConfigFromReq = ({ network, req, source }) => {
 
   const { method, params } = cleanReq
   const isPostMethod = postMethods.includes(method)
-  let fetchUrl = `https://${network}.infura.io/v3/${BRAVE_INFURA_PROJECT_ID}`
+  let fetchUrl = `https://${network}-infura.brave.com/${BRAVE_INFURA_PROJECT_ID}`
 
   if (isPostMethod) {
     fetchParams.method = 'POST'
     fetchParams.headers = {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
+      'X-Eth-Method': method,
       ...(source ? {'Infura-Source': `${source}/${requestOrigin}`} : {}),
     }
 
-    const cacheHeader = getCacheHeader(method)
+    const cacheHeader = getCacheHeader(method, cleanReq)
     if (cacheHeader) {
-      fetchParams.headers[cacheHeader] = 'true'
+      fetchParams.headers[cacheHeader[0]] = cacheHeader[1]
     }
 
     fetchParams.body = JSON.stringify(cleanReq)

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,17 @@ const performFetch = async (network, req, res, source) => {
 
 const createInternalError = (msg) => new JsonRpcError.InternalError(new Error(msg))
 
+const getCacheHeader = (method) => {
+  switch (method) {
+    case 'eth_getBlockByNumber':
+      return 'X-Eth-Get-Block'
+    case 'eth_blockNumber':
+      return 'X-Eth-Block'
+    default:
+      return null
+  }
+}
+
 const fetchConfigFromReq = ({ network, req, source }) => {
   const fetchParams = {}
   const requestOrigin = req.origin || 'internal'
@@ -110,6 +121,12 @@ const fetchConfigFromReq = ({ network, req, source }) => {
       'Content-Type': 'application/json',
       ...(source ? {'Infura-Source': `${source}/${requestOrigin}`} : {}),
     }
+
+    const cacheHeader = getCacheHeader(method)
+    if (cacheHeader) {
+      fetchParams.headers[cacheHeader] = 'true'
+    }
+
     fetchParams.body = JSON.stringify(cleanReq)
   } else {
     fetchParams.method = 'GET'


### PR DESCRIPTION
Fixes: https://github.com/brave/brave-browser/issues/6614

Tests were added to cover the new behavior, old broken tests were also updated (block requests are now `POST` vs `GET` per latest infura API)