### PR TITLE
Add eth_feeHistory RPC method to allowlist

### DIFF
--- a/src/postMethods.js
+++ b/src/postMethods.js
@@ -4,6 +4,7 @@ module.exports = [
   'eth_call',
   'eth_chainId',
   'eth_estimateGas',
+  'eth_feeHistory',
   'eth_gasPrice',
   'eth_getBalance',
   'eth_getBlockByHash',


### PR DESCRIPTION
This JSON-RPC method is required for computing estimates for priority fees
to use after the London hardfork.